### PR TITLE
Timer troubleshooting

### DIFF
--- a/app/src/main/java/com/example/bookstats/app/di/AppModule.kt
+++ b/app/src/main/java/com/example/bookstats/app/di/AppModule.kt
@@ -8,6 +8,7 @@ import com.example.bookstats.features.bookdetails.managers.SessionCalculator
 import com.example.bookstats.features.bookdetails.managers.SessionCalculatorImpl
 import com.example.bookstats.features.realtimesessions.timer.helpers.TimerServiceHelper
 import com.example.bookstats.features.realtimesessions.helpers.CurrentBookDb
+import com.example.bookstats.features.realtimesessions.helpers.ElapsedTimeDb
 import com.example.bookstats.features.realtimesessions.timer.Timer
 import com.example.bookstats.network.ApiService
 import com.example.bookstats.repository.Repository
@@ -63,5 +64,11 @@ class AppModule(private val app: Application) {
     @Provides
     fun provideTimer(): Timer {
         return Timer()
+    }
+
+    @Singleton
+    @Provides
+    fun provideElapsedTimeDb(context: Context): ElapsedTimeDb {
+        return ElapsedTimeDb(context = context)
     }
 }

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/helpers/ElapsedTimeDb.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/helpers/ElapsedTimeDb.kt
@@ -1,0 +1,49 @@
+package com.example.bookstats.features.realtimesessions.helpers
+
+import android.content.Context
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class ElapsedTimeDb @Inject constructor(val context: Context) {
+    private val prefs = context.getSharedPreferences(ELAPSED_TIME, Context.MODE_PRIVATE)
+
+    fun updateElapsedTime(seconds: Float) {
+        val editor = prefs.edit()
+        editor.putFloat(ELAPSED_TIME, seconds)
+        editor.apply()
+    }
+
+    fun getElapsedTime() = prefs.getFloat(ELAPSED_TIME, 0F)
+
+
+    fun getLastPauseTime(): LocalDateTime? {
+        val savedValue = prefs.getString(LAST_PAUSE, null)
+
+        return savedValue?.toLocalDateTime()
+    }
+
+    fun saveLastPause(date: LocalDateTime?) {
+        val editor = prefs.edit()
+        editor.putString(LAST_PAUSE, date.toStringOrNull())
+        editor.apply()
+    }
+
+
+    private fun String?.toLocalDateTime(): LocalDateTime? {
+        if (this == null) return null
+        val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+        return LocalDateTime.parse(this, formatter)
+    }
+
+    private fun LocalDateTime?.toStringOrNull(): String? {
+        if (this == null) return null
+        val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+        return this.format(formatter)
+    }
+
+    companion object {
+        private const val ELAPSED_TIME = "ELAPSED_TIME"
+        private const val LAST_PAUSE = "LAST_PAUSE"
+    }
+}

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/Timer.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/Timer.kt
@@ -39,6 +39,11 @@ class Timer {
         currentMs = 0
     }
 
+    fun setTime(seconds: Float){
+        flow.value = seconds
+        currentMs = (seconds * 1000).toInt()
+    }
+
     companion object {
         private const val DELAY_VALUE = 500
     }

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/TimerService.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/TimerService.kt
@@ -63,13 +63,12 @@ class TimerService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
-        timer = Timer()
         timer.start()
         startForeground(NOTIFICATION_ID, createNotification())
         CoroutineScope(Dispatchers.IO).launch {
             timer.flow.collect { currentMs ->
                 val timerIntent = Intent(TIMER_ACTION)
-                Log.e("currenttime",(currentMs/1000).toString())
+                Log.e("currenttime", (currentMs / 1000).toString())
                 timerIntent.putExtra(CURRENT_MS, currentMs)
                 LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(timerIntent)
                 sendBroadcast(timerIntent)

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/TimerService.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/TimerService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -30,15 +31,19 @@ class TimerService : Service() {
     inner class TimerServiceBinderImpl : Binder(),
         TimerServiceBinder {
         override fun pauseTimer() {
-            stopTimer()
+            this@TimerService.pauseTimer()
         }
 
         override fun resumeTimer() {
             startTimer()
         }
+
+        override fun setTime(seconds: Float) {
+            timer.setTime(seconds)
+        }
     }
 
-    fun stopTimer() {
+    fun pauseTimer() {
         timer.pause()
     }
 
@@ -64,6 +69,7 @@ class TimerService : Service() {
         CoroutineScope(Dispatchers.IO).launch {
             timer.flow.collect { currentMs ->
                 val timerIntent = Intent(TIMER_ACTION)
+                Log.e("currenttime",(currentMs/1000).toString())
                 timerIntent.putExtra(CURRENT_MS, currentMs)
                 LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(timerIntent)
                 sendBroadcast(timerIntent)
@@ -85,7 +91,7 @@ class TimerService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-       val notificationBuilder = NotificationCompat.Builder(this, TIMER_CHANNEL)
+        val notificationBuilder = NotificationCompat.Builder(this, TIMER_CHANNEL)
             .setContentTitle(applicationContext.resources.getString(R.string.session))
             .setContentText(applicationContext.resources.getString(R.string.session_in_progress))
             .setSmallIcon(R.drawable.app_icon)
@@ -98,6 +104,7 @@ class TimerService : Service() {
 
         return notificationBuilder.build()
     }
+
     private fun createNotificationChannel() {
         val importance = NotificationManager.IMPORTANCE_LOW
         val channel = NotificationChannel(TIMER_CHANNEL, TIMER_CHANNEL, importance)

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/helpers/TimerServiceBinder.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/helpers/TimerServiceBinder.kt
@@ -3,4 +3,5 @@ package com.example.bookstats.features.realtimesessions.timer.helpers
 interface TimerServiceBinder {
     fun pauseTimer()
     fun resumeTimer()
+    fun setTime(seconds: Float)
 }

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/helpers/TimerServiceHelper.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/timer/helpers/TimerServiceHelper.kt
@@ -11,7 +11,7 @@ class TimerServiceHelper @Inject constructor(
     private val context: Context
 ) {
     private lateinit var timerUpdateReceiver: BroadcastReceiver
-    private lateinit var binder : TimerService.TimerServiceBinderImpl
+    private lateinit var binder: TimerService.TimerServiceBinderImpl
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
@@ -22,16 +22,16 @@ class TimerServiceHelper @Inject constructor(
         }
     }
 
-    fun pause(){
+    fun pause() {
         binder.pauseTimer()
     }
 
-    fun resume(){
+    fun resume() {
         binder.resumeTimer()
     }
 
     fun registerTimerUpdateReceiver(receiver: BroadcastReceiver) {
-        if(!isServiceRunning()){
+        if (!isServiceRunning()) {
             startService()
         }
         timerUpdateReceiver = receiver
@@ -52,7 +52,7 @@ class TimerServiceHelper @Inject constructor(
         return false
     }
 
-    fun stopService(){
+    fun stopService() {
         val intent = Intent(context, TimerService::class.java)
         intent.action = STOP_SERVICE
         context.unbindService(serviceConnection)
@@ -63,10 +63,18 @@ class TimerServiceHelper @Inject constructor(
         LocalBroadcastManager.getInstance(context).unregisterReceiver(receiver)
     }
 
-    private fun startService(){
+    private fun startService() {
         val intent = Intent(context, TimerService::class.java)
         context.startForegroundService(intent)
         context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
+    }
+
+    fun preserveTimerState() {
+        TODO("Not yet implemented")
+    }
+
+    fun setTime(timeElapsedSeconds: Float) {
+        binder.setTime(timeElapsedSeconds)
     }
 
 

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/ui/RealTimeSessionFragment.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/ui/RealTimeSessionFragment.kt
@@ -160,7 +160,7 @@ class RealTimeSessionFragment : Fragment(), TimerBroadcastListener {
     }
 
     private fun exitWithoutSaving(){
-        viewModel.pauseTimer()
+     //   viewModel.pauseTimer()
         viewModel.endSessionWithoutSaving()
         findNavController().popBackStack()
     }
@@ -172,14 +172,14 @@ class RealTimeSessionFragment : Fragment(), TimerBroadcastListener {
 
     override fun onPause() {
         super.onPause()
-        viewModel.pauseTimer()
+        if(!viewModel.isSessionEnded()){
+            viewModel.pauseTimer()
+        }
     }
 
     override fun onResume() {
         super.onResume()
-        if(viewModel.isSessionStarted()){
             viewModel.resumeTimerState()
-        }
     }
 
     override fun onTimerBroadcastReceiver(currentMs: Float) {

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/ui/RealTimeSessionFragment.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/ui/RealTimeSessionFragment.kt
@@ -170,6 +170,18 @@ class RealTimeSessionFragment : Fragment(), TimerBroadcastListener {
         onBackPressedCallback.remove()
     }
 
+    override fun onPause() {
+        super.onPause()
+        viewModel.pauseTimer()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if(viewModel.isSessionStarted()){
+            viewModel.resumeTimerState()
+        }
+    }
+
     override fun onTimerBroadcastReceiver(currentMs: Float) {
         viewModel.setCurrentMs(currentMs)
     }

--- a/app/src/main/java/com/example/bookstats/features/realtimesessions/viewmodel/RealTimeSessionsViewModelFactory.kt
+++ b/app/src/main/java/com/example/bookstats/features/realtimesessions/viewmodel/RealTimeSessionsViewModelFactory.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.example.bookstats.features.bookdetails.managers.SessionCalculator
 import com.example.bookstats.features.realtimesessions.helpers.CurrentBookDb
+import com.example.bookstats.features.realtimesessions.helpers.ElapsedTimeDb
 import com.example.bookstats.features.realtimesessions.timer.helpers.TimerServiceHelper
 import com.example.bookstats.repository.Repository
 import javax.inject.Inject
@@ -12,6 +13,7 @@ class RealTimeSessionsViewModelFactory @Inject constructor(
     private val repository: Repository,
     private val calculator: SessionCalculator,
     private val currentBookDb: CurrentBookDb,
+    private val elapsedTimeDb: ElapsedTimeDb,
     private val timerServiceHelper: TimerServiceHelper
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -21,6 +23,7 @@ class RealTimeSessionsViewModelFactory @Inject constructor(
                     repository,
                     calculator,
                     currentBookDb,
+                    elapsedTimeDb,
                     timerServiceHelper
                 ) as T
             else ->


### PR DESCRIPTION
Timer stops counting when realtimesession fragment is onPause() 
Instead, it stores the pause time in SharedPreferences and counts the elapsed time when onResume() is called.
This is to prevent the timer from going sleep when the app is being used on a device with ultra-power saving mode.